### PR TITLE
bug/fix tracking exception

### DIFF
--- a/grape-datadog.gemspec
+++ b/grape-datadog.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(spec)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency(%q<grape>, '~>0.19.2')
+  gem.add_runtime_dependency(%q<grape>, '>= 0.11')
   gem.add_runtime_dependency(%q<dogstatsd-ruby>, '=2.0.0')
   gem.add_development_dependency('pry-byebug')
 end

--- a/lib/grape-datadog/version.rb
+++ b/lib/grape-datadog/version.rb
@@ -1,5 +1,5 @@
 module Datadog
   module Grape
-    VERSION = "1.1.1"
+    VERSION = "1.1.2"
   end
 end


### PR DESCRIPTION
- problem 
we are missing record for tracking error 500. The reason is if we has exception in app, and  call `@app.call(env)` , it will raise error and not continue execute rest of code, include send api to datadog.

- solution
  - rescue exception when we call ` @app.call(env)`.
  - remove string `(.json)` from request path.
  - downgrade runtime_dependency grape version for support ruby 1.9.3 and 2.1