### PR TITLE
Fix the deprecate method

### DIFF
--- a/lib/grape-datadog/middleware.rb
+++ b/lib/grape-datadog/middleware.rb
@@ -39,7 +39,7 @@ module Datadog
       private
 
       def request_path_in_datadog_format(env)
-        path = env['api.endpoint'].routes.first.route_path[1..-1].gsub("/", ".").sub(/\(\.:format\)\z/, "").gsub(/\.:(\w+)/, '.{\1}')
+        path = env['api.endpoint'].routes.first.path[1..-1].gsub("/", ".").sub(/\(\.:format\)\z/, "").gsub(/\.:(\w+)/, '.{\1}')
         path.slice!('(.json)')
         path
       end

--- a/lib/grape-datadog/version.rb
+++ b/lib/grape-datadog/version.rb
@@ -1,5 +1,5 @@
 module Datadog
   module Grape
-    VERSION = "1.1.2"
+    VERSION = "1.1.3"
   end
 end


### PR DESCRIPTION
The route_path will show deprecate warning,

Use the `path` which is mentioned in the warning msg